### PR TITLE
feat: add npm mirror config support

### DIFF
--- a/runtime/node.go
+++ b/runtime/node.go
@@ -172,6 +172,8 @@ FROM base AS deps
 WORKDIR /app
 COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* bun.lockb* ./
 ARG INSTALL_CMD={{.InstallCMD}}
+ARG NPM_MIRROR=
+RUN if [ ! -z "${NPM_MIRROR}" ]; then npm config set registry ${NPM_MIRROR}; fi
 RUN if [ ! -z "${INSTALL_CMD}" ]; then echo "${INSTALL_CMD}" > dep.sh; sh dep.sh; fi
 
 FROM base AS builder


### PR DESCRIPTION
Sometimes it might be not easy to download deps without an npm mirror server. For example, `https://registry.npmmirror.com` is a very popular mirror server.